### PR TITLE
feat: add PartialCloneToDir and PartialCloneClusterRepo helpers

### DIFF
--- a/pkg/gitclient/helpers.go
+++ b/pkg/gitclient/helpers.go
@@ -331,17 +331,9 @@ func NthTag(g Interface, dir string, n int) (string, string, error) {
 
 // CloneToDir clones the git repository to either the given directory or create a temporary
 func CloneToDir(g Interface, gitURL, dir string) (string, error) {
-	var err error
-	if dir != "" {
-		err = os.MkdirAll(dir, util.DefaultWritePermissions)
-		if err != nil {
-			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
-		}
-	} else {
-		dir, err = os.MkdirTemp("", "jx-git-")
-		if err != nil {
-			return "", fmt.Errorf("failed to create temporary directory: %w", err)
-		}
+	dir, err := createDir(dir)
+	if err != nil {
+		return "", err
 	}
 
 	log.Logger().Debugf("cloning %s to directory %s", termcolor.ColorInfo(gitURL), termcolor.ColorInfo(dir))
@@ -359,17 +351,9 @@ func CloneToDir(g Interface, gitURL, dir string) (string, error) {
 // sparseCheckoutPatterns not supported
 // If shallow is true the clone is made with --depth=1
 func PartialCloneToDir(g Interface, gitURL, dir string, shallow bool) (string, error) {
-	var err error
-	if dir != "" {
-		err = os.MkdirAll(dir, util.DefaultWritePermissions)
-		if err != nil {
-			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
-		}
-	} else {
-		dir, err = os.MkdirTemp("", "jx-git-")
-		if err != nil {
-			return "", fmt.Errorf("failed to create temporary directory: %w", err)
-		}
+	dir, err := createDir(dir)
+	if err != nil {
+		return "", err
 	}
 
 	log.Logger().Debugf("shallow cloning %s to directory %s", termcolor.ColorInfo(gitURL), termcolor.ColorInfo(dir))
@@ -392,17 +376,9 @@ func PartialCloneToDir(g Interface, gitURL, dir string, shallow bool) (string, e
 // NOTE: This functionality is experimental and also the behaviour may vary between different git servers.
 // If shallow is true the clone is made with --depth=1
 func SparseCloneToDir(g Interface, gitURL, dir string, shallow bool, sparseCheckoutPatterns ...string) (string, error) {
-	var err error
-	if dir != "" {
-		err = os.MkdirAll(dir, util.DefaultWritePermissions)
-		if err != nil {
-			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
-		}
-	} else {
-		dir, err = os.MkdirTemp("", "jx-git-")
-		if err != nil {
-			return "", fmt.Errorf("failed to create temporary directory: %w", err)
-		}
+	dir, err := createDir(dir)
+	if err != nil {
+		return "", err
 	}
 
 	log.Logger().Debugf("cloning %s to directory %s sparsely", termcolor.ColorInfo(gitURL), termcolor.ColorInfo(dir))
@@ -596,6 +572,24 @@ func CheckoutRemoteBranch(g Interface, dir string, branch string) error {
 		return nil
 	}
 	return Checkout(g, dir, branch)
+}
+
+// createDir creates input directory if it does not exist, or creates a temporary directory
+// createDir creates the input directory if it does not exist, or creates a temporary directory
+func createDir(dir string) (string, error) {
+	var err error
+	if dir != "" {
+		err = os.MkdirAll(dir, util.DefaultWritePermissions)
+		if err != nil {
+			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	} else {
+		dir, err = os.MkdirTemp("", "jx-git-")
+		if err != nil {
+			return "", fmt.Errorf("failed to create temporary directory: %w", err)
+		}
+	}
+	return dir, nil
 }
 
 // GetLatestCommitMessage returns the latest git commit message

--- a/pkg/gitclient/helpers.go
+++ b/pkg/gitclient/helpers.go
@@ -354,6 +354,32 @@ func CloneToDir(g Interface, gitURL, dir string) (string, error) {
 	return dir, nil
 }
 
+// ShallowCloneToDir clones just the HEAD branch and contents of the git repo to the input directory
+func ShallowCloneToDir(g Interface, gitURL, dir string) (string, error) {
+	var err error
+	if dir != "" {
+		err = os.MkdirAll(dir, util.DefaultWritePermissions)
+		if err != nil {
+			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	} else {
+		dir, err = os.MkdirTemp("", "jx-git-")
+		if err != nil {
+			return "", fmt.Errorf("failed to create temporary directory: %w", err)
+		}
+	}
+
+	log.Logger().Debugf("shallow cloning %s to directory %s", termcolor.ColorInfo(gitURL), termcolor.ColorInfo(dir))
+
+	parentDir := filepath.Dir(dir)
+	sparseCloneArgs := []string{"clone", "--depth=1"}
+	_, err = g.Command(parentDir, append(sparseCloneArgs, gitURL, dir)...)
+	if err != nil {
+		return "", fmt.Errorf("failed to shallowly clone repository %s to directory: %s: %w", gitURL, dir, err)
+	}
+	return dir, nil
+}
+
 // SparseCloneToDir clones the git repository sparsely to either the given directory or create a temporary on.
 // SparseCheckoutPatterns are checked out interpreted as in .gitignore. If no sparseCheckoutPatterns are given the files
 // directly under the root of the repository are checked out.

--- a/pkg/gitclient/helpers.go
+++ b/pkg/gitclient/helpers.go
@@ -354,8 +354,8 @@ func CloneToDir(g Interface, gitURL, dir string) (string, error) {
 	return dir, nil
 }
 
-// ShallowCloneToDir clones just the HEAD branch and contents of the git repo to the input directory
-func ShallowCloneToDir(g Interface, gitURL, dir string) (string, error) {
+// ShallowCheckoutToDir checkout HEAD branch and contents of the repository
+func ShallowCheckoutToDir(g Interface, gitURL, dir string) (string, error) {
 	var err error
 	if dir != "" {
 		err = os.MkdirAll(dir, util.DefaultWritePermissions)

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -77,25 +77,17 @@ func CloneClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 	return dir, nil
 }
 
-func CloneClusterRepoSparse(g gitclient.Interface, gitURL string, cloneType string, sparseCheckoutPatterns ...string) (string, error) {
+func CloneClusterRepoShallow(g gitclient.Interface, gitURL string) (string, error) {
 	gitURL, err := gitCredsFromCluster(gitURL)
 	if err != nil {
 		return "", err
 	}
-	// If shallow clone is requested, clone the repo with depth 1
-	if cloneType == "shallow" {
-		dir, err := gitclient.SparseCloneToDir(g, gitURL, "", true, sparseCheckoutPatterns...)
-		if err != nil {
-			return "", fmt.Errorf("failed to shallow clone cluster git repo %s: %w", gitURL, err)
-		}
-		return dir, nil
-	} else {
-		dir, err := gitclient.SparseCloneToDir(g, gitURL, "", false, sparseCheckoutPatterns...)
-		if err != nil {
-			return "", fmt.Errorf("failed to sparse clone cluster git repo %s: %w", gitURL, err)
-		}
-		return dir, nil
+	// shallowly clone HEAD of cluster repo to a temp dir and load the requirements
+	dir, err := gitclient.ShallowCloneToDir(g, gitURL, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to clone cluster git repo %s: %w", gitURL, err)
 	}
+	return dir, nil
 }
 
 // AddUserPasswordToURLFromDir loads the username and password files from the given directory and adds them to the URL if they are found

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -64,7 +64,7 @@ func GetRequirementsAndGit(g gitclient.Interface, gitURL string) (*jxcore.Requir
 func CloneClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 	// if we have a kubernetes secret with git auth mounted to the filesystem when running in cluster
 	// we need to turn it into a git credentials file see https://git-scm.com/docs/git-credential-store
-	gitURL, err := GitCredsFromCluster(gitURL)
+	gitURL, err := gitCredsFromCluster(gitURL)
 	if err != nil {
 		return "", err
 	}
@@ -78,7 +78,7 @@ func CloneClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 }
 
 func CloneClusterRepoSparse(g gitclient.Interface, gitURL string, cloneType string, sparseCheckoutPatterns ...string) (string, error) {
-	gitURL, err := GitCredsFromCluster(gitURL)
+	gitURL, err := gitCredsFromCluster(gitURL)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -61,9 +61,7 @@ func GetRequirementsAndGit(g gitclient.Interface, gitURL string) (*jxcore.Requir
 	return &requirements.Spec, dir, nil
 }
 
-func CloneClusterRepo(g gitclient.Interface, gitURL string, partial, shallow bool, sparseCheckoutPatterns ...string) (string, error) {
-	// if we have a kubernetes secret with git auth mounted to the filesystem when running in cluster
-	// we need to turn it into a git credentials file see https://git-scm.com/docs/git-credential-store
+func CloneClusterRepo(g gitclient.Interface, gitURL string, cloneType string, sparseCheckoutPatterns []string) (string, error) {
 	secretMountPath := os.Getenv(credentialhelper.GIT_SECRET_MOUNT_PATH)
 	if secretMountPath != "" {
 		err := credentialhelper.WriteGitCredentialFromSecretMount()
@@ -83,26 +81,23 @@ func CloneClusterRepo(g gitclient.Interface, gitURL string, partial, shallow boo
 		}
 	}
 
-	if partial {
-		if shallow {
-			dir, err := gitclient.SparseCloneToDir(g, gitURL, "", true, sparseCheckoutPatterns...)
-			if err != nil {
-				return "", fmt.Errorf("failed to shallow clone cluster git repo %s: %w", gitURL, err)
-			}
-			return dir, nil
-		} else {
-			dir, err := gitclient.SparseCloneToDir(g, gitURL, "", false, sparseCheckoutPatterns...)
-			if err != nil {
-				return "", fmt.Errorf("failed to sparse clone cluster git repo %s: %w", gitURL, err)
-			}
-			return dir, nil
-		}
-	} else {
+	// Decide on which clone method to use based on the cloneType flag
+	switch cloneType {
+	case "full":
 		dir, err := gitclient.CloneToDir(g, gitURL, "")
 		if err != nil {
 			return "", fmt.Errorf("failed to clone cluster git repo %s: %w", gitURL, err)
 		}
 		return dir, nil
+	case "partial", "shallow":
+		shallow := (cloneType == "shallow")
+		dir, err := gitclient.SparseCloneToDir(g, gitURL, "", shallow, sparseCheckoutPatterns...)
+		if err != nil {
+			return "", fmt.Errorf("failed to sparse clone cluster git repo %s: %w", gitURL, err)
+		}
+		return dir, nil
+	default:
+		return "", fmt.Errorf("invalid git clone type: %s", cloneType)
 	}
 }
 

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -77,13 +77,13 @@ func CloneClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 	return dir, nil
 }
 
-func CloneClusterRepoShallow(g gitclient.Interface, gitURL string) (string, error) {
+func ShallowCheckoutClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 	gitURL, err := gitCredsFromCluster(gitURL)
 	if err != nil {
 		return "", err
 	}
 	// shallowly clone HEAD of cluster repo to a temp dir and load the requirements
-	dir, err := gitclient.ShallowCloneToDir(g, gitURL, "")
+	dir, err := gitclient.ShallowCheckoutToDir(g, gitURL, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to clone cluster git repo %s: %w", gitURL, err)
 	}

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -77,7 +77,9 @@ func CloneClusterRepo(g gitclient.Interface, gitURL string) (string, error) {
 	return dir, nil
 }
 
-func ShallowCloneClusterRepo(g gitclient.Interface, gitURL string, shallow bool, sparseCheckoutPatterns ...string) (string, error) {
+// PartialCloneClusterRepo clones the cluster repo to a temporary directory and returns the directory path
+// Attempts a sparse clone first, falling back to a partial clone without checkout patterns if sparse clone fails
+func PartialCloneClusterRepo(g gitclient.Interface, gitURL string, shallow bool, sparseCheckoutPatterns ...string) (string, error) {
 	gitURL, err := gitCredsFromCluster(gitURL)
 	if err != nil {
 		return "", err
@@ -86,6 +88,7 @@ func ShallowCloneClusterRepo(g gitclient.Interface, gitURL string, shallow bool,
 	dir, err := gitclient.SparseCloneToDir(g, gitURL, "", shallow, sparseCheckoutPatterns...)
 	if err != nil {
 		log.Logger().Warnf("failed sparse clone of cluster git repo %s: %v", gitURL, err)
+		log.Logger().Warnf("falling back to partial clone without checkout patterns")
 		// If sparse clone fails, fall back to partial clone
 		dir, err = gitclient.PartialCloneToDir(g, gitURL, "", shallow)
 		if err != nil {

--- a/pkg/requirements/requirements.go
+++ b/pkg/requirements/requirements.go
@@ -114,8 +114,7 @@ func AddUserPasswordToURLFromDir(gitURL, path string) (string, error) {
 	return gitURL, nil
 }
 
-// GitCredsFromCluster processes the Git credentials from the secret mount path and updates the gitURL accordingly.
-func GitCredsFromCluster(gitURL string) (string, error) {
+func gitCredsFromCluster(gitURL string) (string, error) {
 	secretMountPath := os.Getenv(credentialhelper.GIT_SECRET_MOUNT_PATH)
 	if secretMountPath != "" {
 		err := credentialhelper.WriteGitCredentialFromSecretMount()


### PR DESCRIPTION
Create `func PartialCloneClusterRepo` which performs:

- A partial git clone of a cluster repo `--filter=blob:none` and an optional shallow clone `--depth=1`, then:
  - A sparse checkout of files in `sparseCheckoutPatterns` using git-sparse-checkout, if supported by the upstream git provider (`func SparseCloneToDir`)
  - A full checkout otherwise