### PR TITLE
refactor: simplify FindServiceURLWithDynamicClient

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -94,78 +94,114 @@ func getIstioVirtualService(dynamicClient dynamic.Interface, namespace, name str
 	return virtualService, err
 }
 
-// getUrlFromVirtualService finds url from virtual services istio
-func getUrlFromVirtualService(virtualService *unstructured.Unstructured) (string, error) {
+// getURLFromVirtualService finds url from virtual services istio
+func getURLFromVirtualService(virtualService *unstructured.Unstructured) (string, error) {
 	vs := virtualService.Object
 	if spec, ok := vs["spec"].(map[string]interface{}); ok {
-		if hosts, ok := spec["hosts"].([]interface{}); ok {
-			return "http://" + fmt.Sprintf("%v", hosts[0]), nil
+		if hosts, ok := spec["hosts"].([]interface{}); ok && len(hosts) > 0 {
+			if host := fmt.Sprintf("%v", hosts[0]); host != "" {
+				return "http://" + host, nil
+			}
 		}
 	}
-	return "", errors.New("No url found in the virtual service")
+	return "", errors.New("no URL found in the Istio virtual service")
 }
 
-// FindUrlFromVsIstio finds the host from istio virtual service
-func FindUrlFromVsIstio(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+// FindURLFromVSIstio finds the host from istio virtual service
+func FindURLFromVSIstio(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+	log.Logger().Debugf("finding url from VS Istio %s in namespace %s", name, namespace)
 	virtualService, err := getIstioVirtualService(dynamicClient, namespace, name)
 	if err != nil {
-		return "", nil
+		switch {
+		// istio is optional: missing resource, CRD or lack of RBAC should not log an error
+		case apierrors.IsNotFound(err), apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+			log.Logger().Debugf("Istio VS %s not reachable in namespace %s", name, namespace)
+			return "", nil
+		default:
+			return "", fmt.Errorf("finding the Istio VS %s in namespace %s: %w", name, namespace, err)
+		}
 	}
-	log.Logger().Debugf("Attempting to find via istio virtual services")
-	return getUrlFromVirtualService(virtualService)
+	log.Logger().Debugf("attempting to find via istio virtual services")
+	return getURLFromVirtualService(virtualService)
+}
+
+
+// FindURLFromIngress finds the URL from the Ingress resource using the kubernetes client
+func FindURLFromIngress(client kubernetes.Interface, namespace string, name string) (string, error) {
+	log.Logger().Debugf("finding Ingress url for %s in namespace %s", name, namespace)
+	ingress, err := client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+	if err != nil {
+		switch {
+		// ingress was not found but no other errors occurred. Log and return nil err
+		case apierrors.IsNotFound(err):
+			log.Logger().Debugf("Ingress %s not found in namespace %s", name, namespace)
+			return "", nil
+		default:
+			return "", fmt.Errorf("finding the ingress %s in namespace %s: %w", name, namespace, err)
+		}
+	}
+	return IngressURL(ingress), nil
+}
+
+// FindURLFromService finds the URL from the service resource using the kubernetes client
+func FindURLFromService(client kubernetes.Interface, namespace string, name string) (string, error) {
+	log.Logger().Debugf("finding service url for %s in namespace %s", name, namespace)
+	service, err := client.CoreV1().Services(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+	if err != nil {
+		switch {
+		// service was not found but no other errors occurred. Log and return nil err
+		case apierrors.IsNotFound(err):
+			log.Logger().Debugf("service %s not found in namespace %s", name, namespace)
+			return "", nil
+		default:
+			return "", fmt.Errorf("finding the service %s in namespace %s: %w", name, namespace, err)
+		}
+	}
+	return GetServiceURL(service), nil
 }
 
 func FindServiceURLWithDynamicClient(client kubernetes.Interface, namespace string, name string, dynamicClient dynamic.Interface) (string, error) {
-	log.Logger().Debugf("Finding service url for %s in namespace %s", name, namespace)
-	svc, err := client.CoreV1().Services(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		err = nil
-	}
+	url, err := FindURLFromService(client, namespace, name)
 	if err != nil {
-		return "", fmt.Errorf("finding the service %s in namespace %s: %w", name, namespace, err)
+		return "", err
 	}
-	answer := ""
-	if svc != nil {
-		answer = GetServiceURL(svc)
+	if url != "" {
+		log.Logger().Debugf("found the service url %s", url)
+		return url, nil
 	}
-	if answer != "" {
-		log.Logger().Debugf("Found service url %s", answer)
-		return answer, nil
-	}
+	log.Logger().Debugf("couldn't find url via service, attempting to look up via ingress")
 
-	log.Logger().Debugf("Couldn't find service url, attempting to look up via ingress")
-
-	// lets try find the service via Ingress
-	ing, err := client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
-		err = nil
-	}
+	// let's try finding the service via Ingress
+	// hold onto genuine lookup failures and attempt further discoveries before surfacing them
+	url, err = FindURLFromIngress(client, namespace, name)
 	if err != nil {
-		log.Logger().Debugf("Unable to finding ingress for %s in namespace %s - err %s", name, namespace, err)
-		url, vs_err := FindUrlFromVsIstio(dynamicClient, namespace, name)
-		if url != "" && vs_err == nil {
-			return url, nil
-		}
-		if vs_err != nil {
-			log.Logger().Debugf("Unable to finding istio for %s in namespace %s - err %s", name, namespace, vs_err)
-		}
-		return "", fmt.Errorf("getting ingress for service %q in namespace %s: %w", name, namespace, err)
+		log.Logger().Debugf("unable to find url via ingress for %s in namespace %s - err %s", name, namespace, err)
 	}
-	url := ""
-
-	url = IngressURL(ing)
-
-	if url == "" {
-		log.Logger().Debugf("Unable to find service url via ingress for %s in namespace %s", name, namespace)
-		url, vs_err := FindUrlFromVsIstio(dynamicClient, namespace, name)
-		if url != "" && vs_err == nil {
-			return url, nil
-		}
-		if vs_err != nil {
-			log.Logger().Debugf("Unable to finding istio for %s in namespace %s - err %s", name, namespace, vs_err)
-		}
+	if url != "" {
+		log.Logger().Debugf("found ingress url %s", url)
+		return url, nil
 	}
-	return url, nil
+
+	log.Logger().Debugf("couldn't find url via ingress, attempting to look up via istio virtual services")
+
+	// let's try finding the service via Istio Virtual Services
+	url, vsErr := FindURLFromVSIstio(dynamicClient, namespace, name)
+	// log errors from Istio but don't propagate them as Istio is an optional dependency
+	if vsErr != nil {
+		log.Logger().Debugf("unable to find url via istio virtual service for %s in namespace %s - err %s", name, namespace, vsErr)
+	}
+	if url != "" {
+		log.Logger().Debugf("Found istio virtual service url %s", url)
+		return url, nil
+	}
+
+	// nothing found anywhere - if a lookup action errored, surface it here
+	if err != nil {
+		return "", err
+	}
+
+	log.Logger().Debugf("couldn't find service url, exiting")
+	return "", nil
 }
 
 func FindServiceURL(client kubernetes.Interface, namespace string, name string) (string, error) {
@@ -300,8 +336,11 @@ func FindService(client kubernetes.Interface, name string) (*v1.Service, error) 
 
 // GetServiceURL returns the
 func GetServiceURL(svc *v1.Service) string {
+	if svc == nil {
+		return ""
+	}
 	url := ""
-	if svc != nil && svc.Annotations != nil {
+	if svc.Annotations != nil {
 		url = svc.Annotations[ExposeURLAnnotation]
 	}
 	if url == "" {

--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -4,18 +4,32 @@
 package services_test
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/jenkins-x/jx-helpers/v3/pkg/kube"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/kube/services"
+	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	nv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	fakedyn "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
+
+func TestMain(m *testing.M) {
+	// warm up jx-logging before parallel tests fan out to prevent a global init race
+	log.Logger()
+	os.Exit(m.Run())
+}
 
 func TestExtractServiceSchemePortDefault(t *testing.T) {
 	t.Parallel()
@@ -297,7 +311,7 @@ func TestExtractServiceSchemePortInconclusive(t *testing.T) {
 	assert.Equal(t, "", port)
 }
 
-func TestFindURLFromIngress(t *testing.T) {
+func TestIngressURL(t *testing.T) {
 	t.Parallel()
 
 	type testData struct {
@@ -423,14 +437,15 @@ func TestFindURLFromIngress(t *testing.T) {
 	}
 }
 
-func TestGetUrlFromVirtualService(t *testing.T) {
+func TestGetURLFromVirtualService(t *testing.T) {
+	t.Parallel()
 	var namespace = "default"
 	var name = "jenkins"
 	// case when there is no virtual service
 	scheme := runtime.NewScheme()
 	dynamicClient := fakedyn.NewSimpleDynamicClient(scheme)
-	url, err := services.FindUrlFromVsIstio(dynamicClient, namespace, name)
-	assert.Equal(t, url, "")
+	url, err := services.FindURLFromVSIstio(dynamicClient, namespace, name)
+	assert.Equal(t, "", url)
 	assert.NoError(t, err)
 	// case with a virtual service in the given namespace
 	virtualService := &unstructured.Unstructured{}
@@ -446,9 +461,211 @@ func TestGetUrlFromVirtualService(t *testing.T) {
 		},
 	})
 	dynamicClient = fakedyn.NewSimpleDynamicClient(scheme, virtualService)
-	url, err = services.FindUrlFromVsIstio(dynamicClient, namespace, name)
+	url, err = services.FindURLFromVSIstio(dynamicClient, namespace, name)
 	if assert.NoError(t, err) {
-		assert.Equal(t, url, "http://testing.jenkins-x.in")
+		assert.Equal(t, "http://testing.jenkins-x.in", url)
 	}
-	assert.Equal(t, err, nil)
+	// case with a virtual service whose spec.hosts is present but empty: must not panic and yields no URL
+	emptyHostsVS := &unstructured.Unstructured{}
+	emptyHostsVS.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind":       "VirtualService",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]interface{}{
+			"hosts": []interface{}{},
+		},
+	})
+	dynamicClient = fakedyn.NewSimpleDynamicClient(scheme, emptyHostsVS)
+	url, err = services.FindURLFromVSIstio(dynamicClient, namespace, name)
+	assert.Error(t, err)
+	assert.Equal(t, "", url)
+	// istio is optional: forbidden/unauthorized GETs are swallowed to ("", nil) rather than surfaced
+	for _, swallowed := range []struct {
+		name string
+		err  error
+	}{
+		{"forbidden", apierrors.NewForbidden(schema.GroupResource{Resource: "virtualservices"}, name, fmt.Errorf("nope"))},
+		{"unauthorized", apierrors.NewUnauthorized("nope")},
+	} {
+		errClient := fakedyn.NewSimpleDynamicClient(scheme)
+		errClient.PrependReactor("get", "virtualservices", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, swallowed.err
+		})
+		url, err = services.FindURLFromVSIstio(errClient, namespace, name)
+		assert.NoError(t, err, swallowed.name)
+		assert.Equal(t, "", url, swallowed.name)
+	}
+}
+
+func TestFindURLFromService(t *testing.T) {
+	t.Parallel()
+	const namespace = "jx"
+
+	// service does not exist -> empty url, no error
+	client := fake.NewSimpleClientset()
+	url, err := services.FindURLFromService(client, namespace, "missing")
+	assert.NoError(t, err)
+	assert.Equal(t, "", url)
+
+	// service with the expose url annotation -> annotation value
+	client = fake.NewSimpleClientset(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "exposed",
+			Namespace:   namespace,
+			Annotations: map[string]string{services.ExposeURLAnnotation: "https://exposed.example.com"},
+		},
+	})
+	url, err = services.FindURLFromService(client, namespace, "exposed")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://exposed.example.com", url)
+
+	// LoadBalancer service without annotation -> GetServiceURL fallback to the ingress IP
+	client = fake.NewSimpleClientset(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lb",
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+			},
+		},
+	})
+	url, err = services.FindURLFromService(client, namespace, "lb")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://1.2.3.4/", url)
+}
+
+func TestFindURLFromIngress(t *testing.T) {
+	t.Parallel()
+	const namespace = "jx"
+
+	// ingress does not exist -> empty url, no error
+	client := fake.NewSimpleClientset()
+	url, err := services.FindURLFromIngress(client, namespace, "missing")
+	assert.NoError(t, err)
+	assert.Equal(t, "", url)
+
+	// ingress present -> IngressURL result
+	client = fake.NewSimpleClientset(&nv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hook",
+			Namespace: namespace,
+		},
+		Spec: nv1.IngressSpec{
+			Rules: []nv1.IngressRule{{Host: "hook-jx.1.2.3.4.nip.io"}},
+		},
+	})
+	url, err = services.FindURLFromIngress(client, namespace, "hook")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://hook-jx.1.2.3.4.nip.io", url)
+}
+
+// TestFindServiceURLWithDynamicClient checks the orchestration of URL searching across all resource types
+func TestFindServiceURLWithDynamicClient(t *testing.T) {
+	t.Parallel()
+	const namespace = "jx"
+	const name = "myapp"
+
+	vsWithHost := &unstructured.Unstructured{}
+	vsWithHost.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind":       "VirtualService",
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+		"spec":       map[string]interface{}{"hosts": []interface{}{"myapp.example.com"}},
+	})
+
+	// clientset whose service GET fails with a non-NotFound error
+	errClient := fake.NewSimpleClientset()
+	errClient.PrependReactor("get", "services", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("boom")
+	})
+
+	// clientset whose ingress GET fails with a non-NotFound error (e.g. forbidden),
+	// while the service is simply absent - discovery should still fall through to istio
+	ingErrClient := fake.NewSimpleClientset()
+	ingErrClient.PrependReactor("get", "ingresses", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "ingresses"}, name, fmt.Errorf("nope"))
+	})
+
+	testCases := []struct {
+		name          string
+		client        *fake.Clientset
+		dynamicClient dynamic.Interface
+		expectedURL   string
+		expectErr     bool
+	}{
+		{
+			name: "service wins (no fall-through)",
+			client: fake.NewSimpleClientset(&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   namespace,
+					Annotations: map[string]string{services.ExposeURLAnnotation: "https://svc.example.com"},
+				},
+			}),
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectedURL:   "https://svc.example.com",
+		},
+		{
+			name: "falls through to ingress",
+			client: fake.NewSimpleClientset(&nv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       nv1.IngressSpec{Rules: []nv1.IngressRule{{Host: "ing.example.com"}}},
+			}),
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectedURL:   "http://ing.example.com",
+		},
+		{
+			name:          "falls through to istio",
+			client:        fake.NewSimpleClientset(),
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), vsWithHost),
+			expectedURL:   "http://myapp.example.com",
+		},
+		{
+			name:          "nothing found",
+			client:        fake.NewSimpleClientset(),
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectedURL:   "",
+		},
+		{
+			name:          "service error propagates",
+			client:        errClient,
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectErr:     true,
+		},
+		{
+			name:          "ingress error falls through to istio",
+			client:        ingErrClient,
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), vsWithHost),
+			expectedURL:   "http://myapp.example.com",
+		},
+		{
+			name:          "ingress error surfaces when nothing else found",
+			client:        ingErrClient,
+			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
+			expectErr:     true,
+			expectedURL:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			url, err := services.FindServiceURLWithDynamicClient(tc.client, namespace, name, tc.dynamicClient)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedURL, url)
+		})
+	}
 }


### PR DESCRIPTION
### Changes
* Create `FindUrlFromIngress` and `FindUrlFromService` helpers
* Simplify `FindServiceURLWithDynamicClient` for clearer composability
* Add tests to cover the helpers and client discovery in different scenarios

### Context

This refactor preserves the current logical structure of `FindServiceURLWithDynamicClient` while making it easier to work with.

`FindUrlFromService` and `FindUrlFromIngress` now handle service and ingress URL discovery. Other public methods are unchanged to preserve backwards compatibility.

`FindServiceURLWithDynamicClient` is used by `jx-preview` to generate preview URLs, and this change simplifies adding new URL sources (i.e.: `HTTPRoute`s).