### PR TITLE
feat: add HTTPRoute as source for service URL finder

### DIFF
--- a/pkg/kube/services/services.go
+++ b/pkg/kube/services/services.go
@@ -125,6 +125,151 @@ func FindURLFromVSIstio(dynamicClient dynamic.Interface, namespace, name string)
 	return getURLFromVirtualService(virtualService)
 }
 
+func getHTTPRoute(dynamicClient dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	dynamicClient, err := kube.LazyCreateDynamicClient(dynamicClient)
+	if err != nil {
+		return nil, err
+	}
+	// Create a GVR for a HTTPRoute
+	httpRouteGVR := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "httproutes",
+	}
+	httpRoute, err := dynamicClient.Resource(httpRouteGVR).Namespace(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return httpRoute, nil
+}
+
+func getGateway(dynamicClient dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	dynamicClient, err := kube.LazyCreateDynamicClient(dynamicClient)
+	if err != nil {
+		return nil, err
+	}
+	// Create a GVR for a Gateway
+	gatewayGVR := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "gateways",
+	}
+	gateway, err := dynamicClient.Resource(gatewayGVR).Namespace(namespace).Get(context.TODO(), name, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return gateway, nil
+}
+
+// getGatewayListenerProtocol gets the protocol (HTTP or HTTPS) of the listener attached to the HTTPRoute via its parentRefs
+func getGatewayListenerProtocol(dynamicClient dynamic.Interface, httpRoute *unstructured.Unstructured) (string, error) {
+	spec, ok := httpRoute.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("no spec found in the HTTPRoute")
+	}
+	parentRefs, ok := spec["parentRefs"].([]interface{})
+	if !ok || len(parentRefs) == 0 {
+		return "", errors.New("no parentRefs found in the HTTPRoute")
+	}
+	parentRef, ok := parentRefs[0].(map[string]interface{})
+	if !ok {
+		return "", errors.New("invalid parentRef in the HTTPRoute")
+	}
+	gatewayName, _ := parentRef["name"].(string)
+	if gatewayName == "" {
+		return "", errors.New("no parent Gateway name in the HTTPRoute")
+	}
+	// the parent Gateway defaults to the HTTPRoute's namespace unless explicitly set
+	gatewayNamespace := httpRoute.GetNamespace()
+	if ns, ok := parentRef["namespace"].(string); ok && ns != "" {
+		gatewayNamespace = ns
+	}
+	// sectionName optionally pins a specific listener on the Gateway
+	sectionName, _ := parentRef["sectionName"].(string)
+
+	gateway, err := getGateway(dynamicClient, gatewayNamespace, gatewayName)
+	if err != nil {
+		return "", err
+	}
+	return getListenerProtocol(gateway, sectionName)
+}
+
+// getListenerProtocol returns the protocol of the Gateway listener named by sectionName,
+// or the first listener's protocol when sectionName is empty
+func getListenerProtocol(gateway *unstructured.Unstructured, sectionName string) (string, error) {
+	spec, ok := gateway.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("no spec found in the Gateway")
+	}
+	listeners, ok := spec["listeners"].([]interface{})
+	if !ok || len(listeners) == 0 {
+		return "", errors.New("no listeners found in the Gateway")
+	}
+	for _, l := range listeners {
+		listener, ok := l.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// when a sectionName is given, only the listener with the matching name is relevant
+		if sectionName != "" {
+			if name, _ := listener["name"].(string); name != sectionName {
+				continue
+			}
+		}
+		if protocol, ok := listener["protocol"].(string); ok && protocol != "" {
+			return protocol, nil
+		}
+		// no sectionName: only the first listener is considered
+		if sectionName == "" {
+			break
+		}
+	}
+	return "", errors.New("no matching listener protocol found in the Gateway")
+}
+
+func getURLFromHTTPRoute(dynamicClient dynamic.Interface, httpRoute *unstructured.Unstructured) (string, error) {
+	spec, ok := httpRoute.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("no URL found in the HTTPRoute")
+	}
+	hostnames, ok := spec["hostnames"].([]interface{})
+	if !ok || len(hostnames) == 0 {
+		return "", errors.New("no URL found in the HTTPRoute")
+	}
+	hostname := fmt.Sprintf("%v", hostnames[0])
+	if hostname == "" {
+		return "", errors.New("no URL found in the HTTPRoute")
+	}
+
+	// best-effort: derive the scheme from the parent Gateway listener's protocol,
+	// defaulting to http when the Gateway is unreadable so URL discovery still succeeds
+	scheme := "http"
+	protocol, err := getGatewayListenerProtocol(dynamicClient, httpRoute)
+	if err != nil {
+		log.Logger().Debugf("unable to determine protocol from parent Gateway listener, defaulting to http: %s", err)
+	} else if strings.EqualFold(protocol, "HTTPS") {
+		scheme = "https"
+	}
+	return scheme + "://" + hostname, nil
+}
+
+// FindURLFromHTTPRoute finds the URL from the HTTPRoute resource
+func FindURLFromHTTPRoute(dynamicClient dynamic.Interface, namespace, name string) (string, error) {
+	log.Logger().Debugf("finding url from HTTP route %s in namespace %s", name, namespace)
+	httpRoute, err := getHTTPRoute(dynamicClient, namespace, name)
+	if err != nil {
+		switch {
+		// HTTPRoute not found but no other errors occurred. Log and return nil err
+		case apierrors.IsNotFound(err):
+			log.Logger().Debugf("HTTPRoute %s not reachable in namespace %s", name, namespace)
+			return "", nil
+		default:
+			return "", fmt.Errorf("finding the HTTP route %s in namespace %s: %w", name, namespace, err)
+		}
+	}
+	log.Logger().Debugf("attempting to find URL via HTTPRoute")
+	return getURLFromHTTPRoute(dynamicClient, httpRoute)
+}
 
 // FindURLFromIngress finds the URL from the Ingress resource using the kubernetes client
 func FindURLFromIngress(client kubernetes.Interface, namespace string, name string) (string, error) {
@@ -179,6 +324,19 @@ func FindServiceURLWithDynamicClient(client kubernetes.Interface, namespace stri
 	}
 	if url != "" {
 		log.Logger().Debugf("found ingress url %s", url)
+		return url, nil
+	}
+
+	log.Logger().Debugf("couldn't find url via ingress, attempting to look up via HTTPRoute")
+
+	// let's try finding the URL via HTTPRoute
+	// use a dedicated error variable so an optional HTTPRoute failure doesn't clobber a genuine ingress error
+	url, hrErr := FindURLFromHTTPRoute(dynamicClient, namespace, name)
+	if hrErr != nil {
+		log.Logger().Debugf("unable to find url via HTTPRoute for %s in namespace %s - err %s", name, namespace, hrErr)
+	}
+	if url != "" {
+		log.Logger().Debugf("found HTTPRoute url %s", url)
 		return url, nil
 	}
 

--- a/pkg/kube/services/services_test.go
+++ b/pkg/kube/services/services_test.go
@@ -25,6 +25,15 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
+// gatewayGVR is the real resource for a Gateway API Gateway. Tests insert Gateways
+// under this GVR explicitly because the fake dynamic client's kind->resource heuristic
+// mispluralises "Gateway" to "gatewaies".
+var gatewayGVR = schema.GroupVersionResource{
+	Group:    "gateway.networking.k8s.io",
+	Version:  "v1",
+	Resource: "gateways",
+}
+
 func TestMain(m *testing.M) {
 	// warm up jx-logging before parallel tests fan out to prevent a global init race
 	log.Logger()
@@ -500,6 +509,86 @@ func TestGetURLFromVirtualService(t *testing.T) {
 	}
 }
 
+func TestFindURLFromHTTPRoute(t *testing.T) {
+	t.Parallel()
+	const namespace = "jx"
+	const name = "myapp"
+
+	newHTTPRoute := func(hostname, gatewayName, sectionName string) *unstructured.Unstructured {
+		parentRef := map[string]interface{}{"name": gatewayName}
+		if sectionName != "" {
+			parentRef["sectionName"] = sectionName
+		}
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+			"spec": map[string]interface{}{
+				"parentRefs": []interface{}{parentRef},
+				"hostnames":  []interface{}{hostname},
+			},
+		})
+		return u
+	}
+
+	newGateway := func(gatewayName string, listeners ...map[string]interface{}) *unstructured.Unstructured {
+		ls := make([]interface{}, 0, len(listeners))
+		for _, l := range listeners {
+			ls = append(ls, l)
+		}
+		u := &unstructured.Unstructured{}
+		u.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata":   map[string]interface{}{"name": gatewayName, "namespace": namespace},
+			"spec":       map[string]interface{}{"listeners": ls},
+		})
+		return u
+	}
+
+	httpsListener := map[string]interface{}{"name": "https", "protocol": "HTTPS", "port": int64(443)}
+	httpListener := map[string]interface{}{"name": "http", "protocol": "HTTP", "port": int64(80)}
+
+	// newClient seeds a fake dynamic client. The HTTPRoute is added normally, but the Gateway
+	// must be inserted under its real "gateways" resource: the fake client's UnsafeGuessKindToResource
+	// heuristic mispluralises kind "Gateway" to "gatewaies", so a plain Add would not be GET-able.
+	newClient := func(httpRoute, gateway *unstructured.Unstructured) dynamic.Interface {
+		c := fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), httpRoute)
+		if gateway != nil {
+			err := c.Tracker().Create(gatewayGVR, gateway, gateway.GetNamespace())
+			assert.NoError(t, err)
+		}
+		return c
+	}
+
+	// no HTTPRoute present -> empty url, no error (NotFound is swallowed)
+	url, err := services.FindURLFromHTTPRoute(fakedyn.NewSimpleDynamicClient(runtime.NewScheme()), namespace, name)
+	assert.NoError(t, err)
+	assert.Equal(t, "", url)
+
+	// HTTPRoute + Gateway whose pinned listener is HTTPS -> https scheme
+	url, err = services.FindURLFromHTTPRoute(
+		newClient(newHTTPRoute("myapp.example.com", "gw", "https"), newGateway("gw", httpListener, httpsListener)),
+		namespace, name)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://myapp.example.com", url)
+
+	// HTTPRoute + Gateway whose first listener is HTTP (no sectionName) -> http scheme
+	url, err = services.FindURLFromHTTPRoute(
+		newClient(newHTTPRoute("myapp.example.com", "gw", ""), newGateway("gw", httpListener, httpsListener)),
+		namespace, name)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://myapp.example.com", url)
+
+	// HTTPRoute present but the parent Gateway is absent -> best-effort fallback to http
+	url, err = services.FindURLFromHTTPRoute(
+		newClient(newHTTPRoute("myapp.example.com", "missing-gw", "https"), nil),
+		namespace, name)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://myapp.example.com", url)
+}
+
 func TestFindURLFromService(t *testing.T) {
 	t.Parallel()
 	const namespace = "jx"
@@ -581,6 +670,31 @@ func TestFindServiceURLWithDynamicClient(t *testing.T) {
 		"spec":       map[string]interface{}{"hosts": []interface{}{"myapp.example.com"}},
 	})
 
+	httpRoute := &unstructured.Unstructured{}
+	httpRoute.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+		"spec": map[string]interface{}{
+			"parentRefs": []interface{}{map[string]interface{}{"name": "gw", "sectionName": "https"}},
+			"hostnames":  []interface{}{"route.example.com"},
+		},
+	})
+	gateway := &unstructured.Unstructured{}
+	gateway.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]interface{}{"name": "gw", "namespace": namespace},
+		"spec": map[string]interface{}{
+			"listeners": []interface{}{map[string]interface{}{"name": "https", "protocol": "HTTPS", "port": int64(443)}},
+		},
+	})
+	// HTTPRoute is added normally; the Gateway must be inserted under its real "gateways" resource
+	httpRouteClient := fakedyn.NewSimpleDynamicClient(runtime.NewScheme(), httpRoute)
+	if err := httpRouteClient.Tracker().Create(gatewayGVR, gateway, namespace); err != nil {
+		t.Fatal(err)
+	}
+
 	// clientset whose service GET fails with a non-NotFound error
 	errClient := fake.NewSimpleClientset()
 	errClient.PrependReactor("get", "services", func(clienttesting.Action) (bool, runtime.Object, error) {
@@ -621,6 +735,12 @@ func TestFindServiceURLWithDynamicClient(t *testing.T) {
 			}),
 			dynamicClient: fakedyn.NewSimpleDynamicClient(runtime.NewScheme()),
 			expectedURL:   "http://ing.example.com",
+		},
+		{
+			name:          "falls through to HTTPRoute",
+			client:        fake.NewSimpleClientset(),
+			dynamicClient: httpRouteClient,
+			expectedURL:   "https://route.example.com",
 		},
 		{
 			name:          "falls through to istio",


### PR DESCRIPTION
### Changes
* Add `FindURLFromHTTPRoute` to dynamically resolve a service URL for a Gateway API `HTTPRoute` resource
* Add helpers to read the `HTTPRoute`/`Gateway` resources and derive the scheme (http/https) from the parent Gateway listener's protocol, defaulting to http when the Gateway can't be read
* Wire `HTTPRoute` lookup into `FindServiceURLWithDynamicClient`, slotting it in after Ingress and before Istio VirtualServices
* Add test coverage for the new HTTPRoute URL resolution.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                         
### Context
When using the Gateway API, service hostnames are exposed using a `HTTPRoute` rather than `Ingress` or Istio's `VirtualServices`.

This adds HTTPRoute as a source in the URL finder chain so URLs can resolve correctly when the Gateway API is used.